### PR TITLE
 Completed workflow when user runs script then opens the GUI. Made us…

### DIFF
--- a/installer-files/desktop-app/editor-desktop-app/src-tauri/src/App_State/app_state.rs
+++ b/installer-files/desktop-app/editor-desktop-app/src-tauri/src/App_State/app_state.rs
@@ -1,0 +1,12 @@
+use std::sync::{Arc, Mutex};
+
+// This struct keeps track of any necessary state variables for the entire application
+// All variables must be thread safe so that different Rust threads can access the
+// variables without corruption from other threads
+#[derive(Clone, Default)]
+pub struct AppState {
+    //simple bool for whether the home page is fully mounted
+    // This changes via the Is_GUI_Loaded command
+    pub gui_loaded: Arc<Mutex<bool>>,
+    // Add more state variables as needed
+}

--- a/installer-files/desktop-app/editor-desktop-app/src-tauri/src/UI_communication/commands.rs
+++ b/installer-files/desktop-app/editor-desktop-app/src-tauri/src/UI_communication/commands.rs
@@ -1,0 +1,15 @@
+/*
+This file is responsible for listening for events emitted by the React Frontend and 
+taking action on those events. These are essentially all the Tauri Commands the 
+Backend can receive. This ffile is linked in lib.rs
+
+ */
+use crate::App_State::app_state::AppState;
+
+// This is a command that gets called when the frontend has fully mounted
+#[tauri::command]
+pub fn GUI_Loaded(state: tauri::State<AppState>) {
+  println!("GUI Loaded");
+  let mut gui_loaded = state.gui_loaded.lock().unwrap();
+  *gui_loaded = true;
+}

--- a/installer-files/desktop-app/editor-desktop-app/src-tauri/src/lib.rs
+++ b/installer-files/desktop-app/editor-desktop-app/src-tauri/src/lib.rs
@@ -1,17 +1,4 @@
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-#[tauri::command]
-fn greet(name: &str) -> String {
-    format!("Hello, {}! You've been greeted from Rust!", name)
-}
-
-#[cfg_attr(mobile, tauri::mobile_entry_point)]
-pub fn run() {
-    tauri::Builder::default()
-        .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![greet])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
-}
 
 pub mod script_communication {
     pub mod initial_connect;
@@ -22,4 +9,8 @@ pub mod script_communication {
 pub mod UI_communication {
     pub mod app_setup;
     pub mod event_creation_handler;
+    pub mod commands;
+}
+pub mod App_State {
+    pub mod app_state;
 }

--- a/installer-files/desktop-app/editor-desktop-app/src-tauri/src/main.rs
+++ b/installer-files/desktop-app/editor-desktop-app/src-tauri/src/main.rs
@@ -1,12 +1,26 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+// Bring in the AppState struct which safely holds global state variables
+// Note, this needs to be managed by the Tauri builder
+use GameTime_lib::App_State::app_state::AppState; 
+
+// Get the Tauri Commands:
+use GameTime_lib::UI_communication::commands;
+// Get the Setup app function
 use GameTime_lib::UI_communication::app_setup::setup_app;
 
 // Define backend behaviors of the script
 fn main() {
     println!("HELLO from rust app");
+
+    let mut state = AppState::default();  // create a struct managing all state variables
+
     tauri::Builder::default()
+        .manage(state)
+        .invoke_handler(tauri::generate_handler![
+            commands::GUI_Loaded,
+        ])
         .setup(|app| setup_app(app)) // setup app configures state information before launching the actual application
         .run(tauri::generate_context!())
         .expect("failed to run app");

--- a/installer-files/desktop-app/editor-desktop-app/src-tauri/src/script_communication/maintain_stream.rs
+++ b/installer-files/desktop-app/editor-desktop-app/src-tauri/src/script_communication/maintain_stream.rs
@@ -52,6 +52,8 @@ pub fn maintain_socket_connection(stream: UnixStream, app_handle: tauri::AppHand
         if let Ok(msg_from_frontend) = receiver.try_recv() {
             println!("Main thread says: {:#?}", msg_from_frontend);
             // Need code here to process the message and do any needed functionality
+            // This block is for the future when message originate from the User via UI
+            // A file like receive_GUI_message will make calls to send_socket_message::send_message_via_socket() 
         }
 
         // 👂 Check for messages from the script (non-blocking read for now)

--- a/installer-files/desktop-app/editor-desktop-app/src/page_hub/App.jsx
+++ b/installer-files/desktop-app/editor-desktop-app/src/page_hub/App.jsx
@@ -1,10 +1,9 @@
 import { useState, useEffect } from "react";
-import { invoke } from "@tauri-apps/api/core";
 
 import Login from '../pages/LoginPage.jsx';
 import Home from '../pages/HomePage.jsx';
 
-import { once } from '@tauri-apps/api/event';
+import { listen } from '@tauri-apps/api/event';
 
 // This app.jsx file acts as a central hub containing all pages that the user
 // can navigate to. Pages are simply react components found in pages folder.
@@ -15,11 +14,18 @@ function App() {
   const [activePage, setActivePage] = useState('home'); // Track the current page
 
   useEffect(() => {
-    // Listen for the global "show-login" event once
-    once('prompt-user-to-login', () => {
+    // Start listening for global events sent from Rust
+    const unlisten = listen('prompt-user-to-login', () => {
+      console.log("Received prompt-user-to-login event");
       setActivePage('login');
     });
+
+    // Clean up the listener when the component unmounts
+    return () => {
+      unlisten.then((fn) => fn());
+    };
   }, []);
+
   // This function decides what to render based on current page state
   const renderPage = () => {
     switch (activePage) {

--- a/installer-files/desktop-app/editor-desktop-app/src/pages/HomePage.jsx
+++ b/installer-files/desktop-app/editor-desktop-app/src/pages/HomePage.jsx
@@ -1,8 +1,17 @@
 import React from 'react';
 import { Box, SimpleGrid, Text, Image, Button, Flex } from '@chakra-ui/react';
 import launchDemoImage from '../assets/GameTime_Launch_Demo.png';
+import {invoke} from '@tauri-apps/api/core';
+import { useState, useEffect } from "react";
 
 function Home() {
+  useEffect(() => {
+    // Notify backend that the GUI is fully loaded
+    invoke('GUI_Loaded')
+      .then(() => console.log("Tauri command GUI_Loaded was invoked"))
+      .catch(err => console.error("Failed to invoke GUI_Loaded:", err));
+  }, []);
+
   return (
     <Box 
     minH="100vh" // full height of screen


### PR DESCRIPTION
…e of event listeners in useEffect hooks, and tauri event emits to make this happen. Had to create 'prompt-user-to-login' listener in top level app.jsx. Then let useEffect in HomePage to invoke 'GUI_Loaded'. This ensures we are ready to change page before Rust emits teh event to change to the login page. This solves issue #9.